### PR TITLE
added pathing for product images and corrected format of price

### DIFF
--- a/src/pages/Product/Product.tsx
+++ b/src/pages/Product/Product.tsx
@@ -31,10 +31,13 @@ export default function ProductPage() {
 						<li className='product-description'>
 							{product.product_description}
 						</li>
-						<li className='product-price'>{product.price}</li>
-						{/* <li className='product-image'>
-							<img>{product.product_image}</img>
-						</li> */}
+						<li className='product-price'>£{product.price / 100}</li>
+						<li className='product-image'>
+							<img
+								style={{ maxHeight: 200 }}
+								src={'/' + product.product_image}
+							/>
+						</li>
 					</ul>
 				</>
 			) : (


### PR DESCRIPTION
I've fixed the product page so now the image shows up and divided the price by 100, so it shows up correctly:

![image](https://github.com/fac29/hoda-e-commerce-frontend/assets/127022084/4ec6b161-eba2-40c8-8af9-4d9ec8b231b0)

To test this, run `npm run dev` on FE and BE and click on a product from the homepage.