### PR TITLE
commenting out review header for now

### DIFF
--- a/src/components/ReviewCard/ReviewCard.tsx
+++ b/src/components/ReviewCard/ReviewCard.tsx
@@ -36,7 +36,7 @@ export function ReviewCard({
 					);
 				})}
 			</div>
-			<h2>Review header</h2>
+			{/* <h2>Review header</h2> */}
 			<p>{reviewComment}</p>
 		</div>
 	);


### PR DESCRIPTION
We don't have headers in our review object yet so I've commented this out. Reviews now look like this:

![image](https://github.com/fac29/hoda-e-commerce-frontend/assets/127022084/ad419066-1bc4-4a27-acfe-67881d04f3b7)